### PR TITLE
Niels/add queue url output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Terraform module to provision an AWS Cloudwatch Event which posts directly to an
 
 ```hcl
 module "cloudwatch-event-sqs" {
-  source  = "spanio/cloudwatch-event-sqs/aws"
-  version = "1.2"
-  # insert the 1 required variable here
+  source                                    = "spanio/cloudwatch-event-sqs/aws"
+  version                                   = "1.2"
+  cloudwatch_event_rule_schedule_expression = "<cron expression>"
+  # specify other inputs here, as required
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module to provision an AWS Cloudwatch Event which posts directly to an
 ```hcl
 module "cloudwatch-event-sqs" {
   source  = "spanio/cloudwatch-event-sqs/aws"
-  version = "1.0.1"
+  version = "1.2"
   # insert the 1 required variable here
 }
 ```
@@ -34,7 +34,6 @@ module "cloudwatch-event-sqs" {
 | [aws_cloudwatch_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) |
 | [aws_cloudwatch_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) |
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -50,4 +49,5 @@ module "cloudwatch-event-sqs" {
 | Name | Description |
 |------|-------------|
 | sqs_arn | The ARN of the generated SQS queue |
+| queue_url | The URL for the generated SQS queue |
 | sqs_dlq_arn | The ARN of the generated SQS DLQ queue |

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "sqs_arn" {
   description = "The ARN of the generated SQS queue"
   value       = aws_sqs_queue.cron_sqs.arn
 }
+output "queue_url" {
+  description = "The URL for the generated SQS queue"
+  value       = aws_sqs_queue.cron_sqs.url
+}
 output "sqs_dlq_arn" {
   description = "The ARN of the generated SQS DLQ queue"
   value       = aws_sqs_queue.cron_sqs_dlq.arn


### PR DESCRIPTION
Small mod that reflects the `aws_sqs_queue` `url` output.

This allows cron driven Lambdas to retry or backfill by sending messages to the SQS queue that triggers their execution